### PR TITLE
added authorize User user

### DIFF
--- a/src/main/java/ru/netology/authorizationserviceappspringboot/controller/AuthorizationController.java
+++ b/src/main/java/ru/netology/authorizationserviceappspringboot/controller/AuthorizationController.java
@@ -1,11 +1,12 @@
 package ru.netology.authorizationserviceappspringboot.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import ru.netology.authorizationserviceappspringboot.model.Authorities;
+import ru.netology.authorizationserviceappspringboot.model.User;
 import ru.netology.authorizationserviceappspringboot.service.AuthorizationService;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RestController
@@ -18,9 +19,9 @@ public class AuthorizationController {
     }
 
     @GetMapping("/authorize")
-    public List<Authorities> getAuthorities(@RequestParam("user") String user, @RequestParam("password") String password) {
-        System.out.format("[User: %s, password: %s] ", user, password);
-        return service.getAuthorities(user, password);
+    public List<Authorities> getAuthorities(@Valid User user) {
+        System.out.format("[User: %s, password: %s] ", user.getName(), user.getPassword());
+        return service.getAuthorities(user);
     }
 
 }

--- a/src/main/java/ru/netology/authorizationserviceappspringboot/model/User.java
+++ b/src/main/java/ru/netology/authorizationserviceappspringboot/model/User.java
@@ -1,11 +1,19 @@
 package ru.netology.authorizationserviceappspringboot.model;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.Objects;
+
 public class User {
+    @NotBlank
+    @Size(min = 2, max = 20)
     private final String name;
+    @NotBlank
+    @Size(min = 3, max = 8)
     private final String password;
 
-    public User(String name, String password) {
-        this.name = name;
+    public User(String user, String password) {
+        this.name = user;
         this.password = password;
     }
 
@@ -19,9 +27,22 @@ public class User {
 
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(user, user.name) && Objects.equals(password, user.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, password);
+    }
+
+    @Override
     public String toString() {
         return "UserAuthorities{" +
-                "name='" + name + '\'' +
+                "user='" + name + '\'' +
                 ", password='" + password + '\'' +
                 '}';
     }

--- a/src/main/java/ru/netology/authorizationserviceappspringboot/service/AuthorizationService.java
+++ b/src/main/java/ru/netology/authorizationserviceappspringboot/service/AuthorizationService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import ru.netology.authorizationserviceappspringboot.exception.InvalidCredentials;
 import ru.netology.authorizationserviceappspringboot.exception.UnauthorizedUser;
 import ru.netology.authorizationserviceappspringboot.model.Authorities;
+import ru.netology.authorizationserviceappspringboot.model.User;
 import ru.netology.authorizationserviceappspringboot.repository.UserRepository;
 
 import java.util.List;
@@ -17,13 +18,13 @@ public class AuthorizationService {
         this.userRepository = userRepository;
     }
 
-    public List<Authorities> getAuthorities(String user, String password) {
-        if (isEmpty(user) || isEmpty(password)) {
+    public List<Authorities> getAuthorities(User user) {
+        if (isEmpty(user.getName()) || isEmpty(user.getPassword())) {
             throw new InvalidCredentials("User name or password is empty");
         }
-        List<Authorities> userAuthorities = userRepository.getUserAuthorities(user, password);
+        List<Authorities> userAuthorities = userRepository.getUserAuthorities(user.getName(), user.getPassword());
         if (isEmpty(userAuthorities)) {
-            throw new UnauthorizedUser("Unknown user " + user);
+            throw new UnauthorizedUser("Unknown user " + user.getName());
         }
         return userAuthorities;
     }

--- a/src/test/java/ru/netology/authorizationserviceappspringboot/rest-api.http
+++ b/src/test/java/ru/netology/authorizationserviceappspringboot/rest-api.http
@@ -1,19 +1,21 @@
-GET localhost:9000/authorize?user=Ivanov&password=Qwer2022
+
+###
+GET localhost:8080/authorize?user=Ivanov&password=Qwer2022
 
 ###
 
-GET localhost:9000/authorize?user=&password=Qwer2020
+GET localhost:8080/authorize?user=&password=Qwer2020
 
 ###
 
-GET localhost:9000/authorize?user=Vasilev&password=
+GET localhost:8080/authorize?user=Vasilev&password=
 
 ###
-GET localhost:9000/authorize?user=Vasilev&password=Qwer20
+GET localhost:8080/authorize?user=Vasilev&password=Qwer20
 
 ###
 
-GET localhost:9000/authorize?user=Vasilev&password=Qwer2022
+GET localhost:8080/authorize?user=Vasilev&password=Qwer2022
 
 ###
 


### PR DESCRIPTION
Описание
Задача простая: расширить функционал проедыдущего задания "Сервис авторизации"

Теперь ваш контроллер должен принимать не два объекта отдельно, а один объект содержащий значения user и password. Соответственно и AuthorizationService теперь работает с одним объектом. При этом, API для клиента не изменилось и он отправляет запрос такого вида localhost:8080/authorize?user=<ИМЯ_ЮЗЕРА>&password=<ПАРОЛЬ_ЮЗЕРА>. Также вы можете заметить, что вы также должны проверять объект на валидность с помощью аннотации @Valid. Подумайте, как вы должны валидировать поля объекта User:

@RestController
public class AuthorizationController {
    AuthorizationService service;
    
    @GetMapping("/authorize")
    public List<Authorities> getAuthorities(@Valid User user) {
        return service.getAuthorities(user);
    }
}